### PR TITLE
fix: harden same-origin proxy handling

### DIFF
--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -134,8 +134,8 @@ func requestOrigin(r *http.Request) string {
 	if r.TLS != nil {
 		scheme = "https"
 	}
-	if forwardedProto := strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-Proto"), ",")[0]); forwardedProto != "" {
-		scheme = strings.ToLower(forwardedProto)
+	if forwardedProto := strings.ToLower(strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-Proto"), ",")[0])); forwardedProto == "http" || forwardedProto == "https" {
+		scheme = forwardedProto
 	}
 	return normalizeOrigin(scheme + "://" + r.Host)
 }

--- a/internal/http/middleware_test.go
+++ b/internal/http/middleware_test.go
@@ -148,6 +148,55 @@ func TestSameOriginMiddlewareAllowsForwardedHTTPSOrigin(t *testing.T) {
 	}
 }
 
+func TestSameOriginMiddlewareAllowsRefererFallback(t *testing.T) {
+	next := newSameOriginMiddleware(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "https://anthology.example.test/api/items", nil)
+	req.Header.Set("Referer", "https://anthology.example.test/items/new")
+	rec := httptest.NewRecorder()
+
+	next.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", rec.Code)
+	}
+}
+
+func TestSameOriginMiddlewareRejectsCrossSiteReferer(t *testing.T) {
+	next := newSameOriginMiddleware(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "https://anthology.example.test/api/items", nil)
+	req.Header.Set("Referer", "https://evil.example.test/attack")
+	rec := httptest.NewRecorder()
+
+	next.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", rec.Code)
+	}
+}
+
+func TestSameOriginMiddlewareIgnoresInvalidForwardedProto(t *testing.T) {
+	next := newSameOriginMiddleware(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://anthology.example.test/api/items", nil)
+	req.Header.Set("X-Forwarded-Proto", "gopher")
+	req.Header.Set("Origin", "http://anthology.example.test")
+	rec := httptest.NewRecorder()
+
+	next.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", rec.Code)
+	}
+}
+
 func TestSameOriginMiddlewareRejectsCrossSiteOrigin(t *testing.T) {
 	next := newSameOriginMiddleware([]string{"http://localhost:4200"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
## Summary
- restrict X-Forwarded-Proto handling to http/https before using it in same-origin checks
- add Referer fallback coverage and invalid forwarded-proto coverage
- preserve missing Origin/Referer rejection to match the PermitPal CSRF pattern

## Tests
- GOTOOLCHAIN=go1.26.3 go test ./...
- GOTOOLCHAIN=go1.26.3 govulncheck ./...
- GOTOOLCHAIN=go1.26.3 go build ./...