### PR TITLE
[codex] Add Tailscale deployment networking

### DIFF
--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -4,12 +4,11 @@ on:
   push:
     branches: [ main ]
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   build-and-trigger:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-24.04-arm
     environment:
       name: crystal1
@@ -34,7 +33,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v4
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           audience: ${{ secrets.TS_AUDIENCE }}

--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -29,9 +29,6 @@ jobs:
         id: meta
         run: echo "TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Connect to Tailscale
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
@@ -39,6 +36,9 @@ jobs:
           audience: ${{ vars.TS_AUDIENCE }}
           tags: tag:ci
           ping: ${{ env.MANAGER_HOST }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to registry
         uses: docker/login-action@v4

--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-and-trigger:
     runs-on: ubuntu-24.04-arm
@@ -28,6 +32,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:ci
+          ping: ${{ vars.MANAGER_HOST }}
 
       - name: Log in to registry
         uses: docker/login-action@v4

--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -36,9 +36,9 @@ jobs:
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          audience: ${{ secrets.TS_AUDIENCE }}
+          audience: ${{ vars.TS_AUDIENCE }}
           tags: tag:ci
-          ping: ${{ vars.MANAGER_HOST }}
+          ping: ${{ env.MANAGER_HOST }}
 
       - name: Log in to registry
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary
- Adds `tailscale/github-action@v4` before Docker registry login and deploy SSH.
- Grants `contents: read` and `id-token: write` for Tailscale workload identity.
- Uses `TS_OAUTH_CLIENT_ID`, `TS_AUDIENCE`, and `MANAGER_HOST` from the `crystal1` GitHub environment.

## Validation
- `git diff --check`
- Ruby YAML parse of workflow file

## Operational notes
- Merge after the `home_swarm` Traefik/DNS changes are reviewed and deployed.
- Public 22 and 9000 port forwards should stay enabled until a main-branch deploy succeeds through Tailscale.