### PR TITLE
[codex] Route registry over Tailscale in CI

### DIFF
--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -37,6 +37,26 @@ jobs:
           tags: tag:ci
           ping: ${{ env.MANAGER_HOST }}
 
+      - name: Route registry over Tailscale
+        run: |
+          set -euo pipefail
+          registry_host="${IMAGE_REG%%/*}"
+          registry_host="${registry_host%%:*}"
+          manager_ip="$(getent ahostsv4 "${MANAGER_HOST}" | awk '{print $1; exit}')"
+          if [[ -z "${registry_host}" || -z "${manager_ip}" ]]; then
+            echo "Unable to resolve registry host or manager Tailscale IP" >&2
+            exit 1
+          fi
+          if [[ ! "${manager_ip}" =~ ^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            echo "Resolved manager IP ${manager_ip} is not in the Tailscale CGNAT range" >&2
+            exit 1
+          fi
+          echo "Routing ${registry_host} to ${manager_ip} over Tailscale"
+          escaped_registry_host="${registry_host//./\\.}"
+          sudo sed -i.bak "/[[:space:]]${escaped_registry_host}$/d" /etc/hosts
+          echo "${manager_ip} ${registry_host}" | sudo tee -a /etc/hosts
+          getent hosts "${registry_host}"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 


### PR DESCRIPTION
## Summary
- add an /etc/hosts entry after Tailscale connects so IMAGE_REG resolves to the Swarm manager Tailscale IP
- keep registry image pushes private even when public DNS points at the WAN for HTTP-01 certificate validation

## Validation
- parsed workflow YAML with Ruby YAML
- ran git diff --check