### PR TITLE
Cover request log levels

### DIFF
--- a/internal/http/middleware_test.go
+++ b/internal/http/middleware_test.go
@@ -1,11 +1,13 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -210,5 +212,62 @@ func TestSameOriginMiddlewareRejectsCrossSiteOrigin(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected status 403, got %d", rec.Code)
+	}
+}
+
+func TestSlogMiddlewareEmitsDebugAccessLog(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	next := newSlogMiddleware(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	next.ServeHTTP(rec, req)
+
+	logs := buf.String()
+	if !strings.Contains(logs, "http request") {
+		t.Fatalf("log output = %q, want request log", logs)
+	}
+	if !strings.Contains(logs, "path=/health") {
+		t.Fatalf("log output = %q, want path", logs)
+	}
+	if !strings.Contains(logs, "status=204") {
+		t.Fatalf("log output = %q, want status", logs)
+	}
+	if !strings.Contains(logs, "level=DEBUG") {
+		t.Fatalf("log output = %q, want debug level", logs)
+	}
+}
+
+func TestSlogMiddlewareElevatesClientAndServerErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		code  int
+		level string
+	}{
+		{name: "client error", code: http.StatusNotFound, level: "level=WARN"},
+		{name: "server error", code: http.StatusInternalServerError, level: "level=ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			next := newSlogMiddleware(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.code)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+			rec := httptest.NewRecorder()
+
+			next.ServeHTTP(rec, req)
+
+			if logs := buf.String(); !strings.Contains(logs, tt.level) {
+				t.Fatalf("log output = %q, want %s", logs, tt.level)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- add API middleware coverage for request log levels
- verify successful access logs stay DEBUG-only
- verify 4xx request logs are WARN and 5xx request logs are ERROR

## Validation
- make api-test
- commit hook: golangci-lint and Angular lint
