### PR TITLE
[codex] Update Go to 1.26.4

### DIFF
--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -21,7 +21,7 @@ jobs:
       MANAGER_REPO_PATH: ${{ vars.MANAGER_REPO_PATH }}
       PLATFORMS: linux/arm64/v8
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture
 
-Two-tier catalogue: Go 1.25 API + Angular 21 Material UI, deployed as independent containers.
+Two-tier catalogue: Go 1.26 API + Angular 21 Material UI, deployed as independent containers.
 
 ### Go Backend (`cmd/api`, `internal/`)
 - **chi router** with middleware for request IDs, timeouts, structured logging (slog)

--- a/Docker/Dockerfile.api
+++ b/Docker/Dockerfile.api
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.26.3-alpine3.23 AS builder
+FROM golang:1.26.4-alpine3.23 AS builder
 ARG VERSION=dev
 ARG REVISION=unknown
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you are new to the project, start with [`docs/architecture/overview.md`](docs
 
 ## Backend (Go)
 
-* Go 1.25 with structured logging via `log/slog`.
+* Go 1.26 with structured logging via `log/slog`.
 * HTTP routing handled by `chi`, with middleware for request IDs, timeouts, and structured logging.
 * Postgres repositories in `internal/items` and `internal/shelves` handle persistence, shelf layouts, and item placement.
 * Metadata lookups (`internal/catalog`) call the Google Books API. `/api/catalog/lookup` proxies those queries so the Angular UI can search by ISBN or keyword without exposing API tokens.

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -5,7 +5,7 @@ This guide walks through setting up Anthology for local development with full OA
 ## Prerequisites
 
 - PostgreSQL database running locally
-- Go 1.25+
+- Go 1.26+
 - Node.js 24+ (for Angular frontend)
 - Google Cloud account
 

--- a/docs/architecture/api-deep-dive.md
+++ b/docs/architecture/api-deep-dive.md
@@ -4,7 +4,7 @@ This document reflects the current API implementation under `cmd/api` and `inter
 
 ## High-level shape
 
-* Go 1.25, chi router, `slog` logging.
+* Go 1.26, chi router, `slog` logging.
 * Runtime config from env/_FILE (see **Configuration**).
 * Requires Postgres (sqlx, embedded Goose migrations).
 * Metadata lookups proxy Google Books; CSV import reuses that pipeline.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -5,7 +5,7 @@ Anthology is a split-stack application with a stateless Go API and an Angular Ma
 | Layer | Technology | Responsibilities |
 | ----- | ---------- | ---------------- |
 | Frontend | Angular 21 + Angular Material | Authentication UI, catalogue browse experience, Add Item workflows (search, manual entry, CSV import). |
-| Backend | Go 1.25 (`cmd/api`) | REST API for CRUD, CSV ingestion endpoint, metadata lookup proxy, session management. |
+| Backend | Go 1.26 (`cmd/api`) | REST API for CRUD, CSV ingestion endpoint, metadata lookup proxy, session management. |
 | Data | Postgres (`internal/items`) | Persists catalog items. |
 | External APIs | Google Books API | Provides metadata for ISBN/keyword searches and CSV enrichment. |
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module anthology
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0


### PR DESCRIPTION
## Summary
- bump go.mod to Go 1.26.4
- update the API Docker builder image to golang:1.26.4-alpine3.23
- update GitHub Actions checkout/setup-node majors and stale Go 1.25 docs

## Validation
- PATH=/Users/daniel/sdk/go1.26.4/bin:/Users/daniel/go/bin:$PATH go test ./...
- PATH=/Users/daniel/sdk/go1.26.4/bin:/Users/daniel/go/bin:$PATH go build ./...
- PATH=/Users/daniel/sdk/go1.26.4/bin:/Users/daniel/go/bin:$PATH govulncheck ./...
- docker build --pull -f Docker/Dockerfile.api -t codex/anthology-api:go1.26.4 .