### PR TITLE
[codex] restrict UI routes to allowlisted paths

### DIFF
--- a/Docker/ui/nginx.conf
+++ b/Docker/ui/nginx.conf
@@ -8,7 +8,7 @@ server {
     index index.html;
 
     location = /health {
-        add_header Content-Type application/json;
+        default_type application/json;
         return 200 '{"status":"ok"}';
     }
 

--- a/Docker/ui/nginx.conf
+++ b/Docker/ui/nginx.conf
@@ -22,28 +22,64 @@ server {
         try_files /index.html =404;
     }
 
+    location = /login/ {
+        return 301 /login$is_args$args;
+    }
+
+    location = /items {
+        try_files /index.html =404;
+    }
+
+    location = /items/ {
+        return 301 /items$is_args$args;
+    }
+
     location = /items/add {
         try_files /index.html =404;
+    }
+
+    location = /items/add/ {
+        return 301 /items/add$is_args$args;
     }
 
     location ~ "^/items/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/edit$" {
         try_files /index.html =404;
     }
 
+    location ~ "^/items/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/edit/$" {
+        return 301 /items/$1/edit$is_args$args;
+    }
+
     location = /shelves {
         try_files /index.html =404;
+    }
+
+    location = /shelves/ {
+        return 301 /shelves$is_args$args;
     }
 
     location = /shelves/add {
         try_files /index.html =404;
     }
 
+    location = /shelves/add/ {
+        return 301 /shelves/add$is_args$args;
+    }
+
     location ~ "^/shelves/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" {
         try_files /index.html =404;
     }
 
+    location ~ "^/shelves/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/$" {
+        return 301 /shelves/$1$is_args$args;
+    }
+
     location = /series {
         try_files /index.html =404;
+    }
+
+    location = /series/ {
+        return 301 /series$is_args$args;
     }
 
     location / {

--- a/Docker/ui/nginx.conf
+++ b/Docker/ui/nginx.conf
@@ -7,12 +7,46 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-
     location = /health {
         add_header Content-Type application/json;
         return 200 '{"status":"ok"}';
+    }
+
+    # Keep this route allowlist in sync with web/src/app/app.routes.ts.
+    # Unknown direct browser paths should 404 instead of receiving the SPA shell.
+    location = / {
+        try_files /index.html =404;
+    }
+
+    location = /login {
+        try_files /index.html =404;
+    }
+
+    location = /items/add {
+        try_files /index.html =404;
+    }
+
+    location ~ "^/items/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/edit$" {
+        try_files /index.html =404;
+    }
+
+    location = /shelves {
+        try_files /index.html =404;
+    }
+
+    location = /shelves/add {
+        try_files /index.html =404;
+    }
+
+    location ~ "^/shelves/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" {
+        try_files /index.html =404;
+    }
+
+    location = /series {
+        try_files /index.html =404;
+    }
+
+    location / {
+        try_files $uri =404;
     }
 }


### PR DESCRIPTION
## Summary
- Replace the UI nginx catch-all SPA fallback with an explicit allowlist for current Angular routes.
- Preserve static file serving and `/health` while returning 404 for unknown direct paths and scanner-style probes.
- Constrain item edit and shelf detail deep links to UUID-shaped route segments.

## Root Cause
The UI container previously used `try_files $uri $uri/ /index.html`, so unknown paths such as `/ggb.php` received the Angular shell with HTTP 200.

## Validation
- `git diff --check`
- `make web-build` passed; Angular reported the existing initial bundle budget warning.

## Notes
- Docker CLI is installed, but the local Docker daemon was unavailable, so the throwaway nginx container route matrix could not be run locally.
- Future Angular route additions need a matching nginx allowlist entry for direct deep links to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server routing configuration to enforce strict path allowlisting, replacing previous catch-all behavior
  * Non-existent routes now correctly return 404 responses  
  * Added dedicated health check endpoint for monitoring deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->